### PR TITLE
Wait for completion callbacks from runcontrol

### DIFF
--- a/RunControlApp/Db/gencontrolMgr.db
+++ b/RunControlApp/Db/gencontrolMgr.db
@@ -21,7 +21,6 @@ record(aSub, "$(P)CS:$(MODE):_OUT:CNT")
 	field(FTVA, "ULONG")
 	field(SCAN, "1 second")
 	field(PHAS, "2") # so it executes after individual pv range scans
-	field(FLNK, "$(P)CS:$(MODE):_CALC.PROC")
 } 
 
 record(longin, "$(P)CS:$(MODE):OUT:CNT")
@@ -136,30 +135,15 @@ record(calcout, "$(P)CS:$(MODE):IN:TIME:_CALC")
     field(OUT, "$(P)CS:$(MODE):IN:TIME PP")
     field(SCAN, "1 second")
 	field(PHAS, "3")
-}
-
-
-## main calc
-record(calcout, "$(P)CS:$(MODE):_CALC")
-{
-    field(INPA, "$(P)CS:$(MODE):OUT:CNT NPP")
-	field(CALC, "A>0?1:0")
-	field(OOPT, "On Change")
-	field(OCAL, "1")
-	field(DOPT, "Use OCAL")
-	field(OUT, "$(P)CS:$(MODE):_CALC2.PROC PP")
 }	
 
-## this is a bit of a duplicate of above, but is separated
-## so it can be called as part of a sync
 record(calcout, "$(P)CS:$(MODE):_CALC2")
 {
-    field(INPA, "$(P)CS:$(MODE):OUT:CNT NPP")
+    field(INPA, "$(P)CS:$(MODE):OUT:CNT CP")
 	field(CALC, "A>0?2:1")
 	field(OOPT, "Every Time")
 	field(DOPT, "Use CALC")
-	field(OUT, "$(P)CS:$(MODE):_SEQ.SELN")
-	field(FLNK, "$(P)CS:$(MODE):_SEQ.PROC")
+	field(OUT, "$(P)CS:$(MODE):_SEQ.SELN PP")
 }	
 
 record(sseq, "$(P)CS:$(MODE):_SEQ")

--- a/RunControlApp/Db/gencontrolMgr.db
+++ b/RunControlApp/Db/gencontrolMgr.db
@@ -162,13 +162,18 @@ record(calcout, "$(P)CS:$(MODE):_CALC2")
 	field(FLNK, "$(P)CS:$(MODE):_SEQ.PROC")
 }	
 
-record(seq, "$(P)CS:$(MODE):_SEQ")
+record(sseq, "$(P)CS:$(MODE):_SEQ")
 {
     field(SELM, "Mask")
 	field(DOL1, 1)
 	field(DOL2, 1)
-	field(LNK1, "$(IN_ACTION=$(P)CS:$(MODE):DUMMYACT:IN) PP")
-	field(LNK2, "$(OUT_ACTION=$(P)CS:$(MODE):DUMMYACT:OUT) PP")
+    
+    # Must use CA link type to be able to use WAITn - see https://epics.anl.gov/bcda/synApps/std/sseqRecord.html for details.
+	field(LNK1, "$(IN_ACTION=$(P)CS:$(MODE):DUMMYACT:IN) CA")
+    field(WAIT1, "Wait")
+    
+	field(LNK2, "$(OUT_ACTION=$(P)CS:$(MODE):DUMMYACT:OUT) CA")
+    field(WAIT2, "Wait")
 }
 
 ## only trigger change when out of range


### PR DESCRIPTION
https://github.com/ISISComputingGroup/IBEX/issues/5786

Wait for completion callbacks for the runcontrol actions. 

This prevents a race condition which we believe to have caused issue 5786, but were unable to reproduce and write a test for.