### PR TITLE
Write 0 on in-range to handle new SEWAIT PV

### DIFF
--- a/RunControlApp/Db/gencontrolMgr.db
+++ b/RunControlApp/Db/gencontrolMgr.db
@@ -165,7 +165,7 @@ record(calcout, "$(P)CS:$(MODE):_CALC2")
 record(seq, "$(P)CS:$(MODE):_SEQ")
 {
     field(SELM, "Mask")
-	field(DOL1, 1)
+	field(DOL1, 0)
 	field(DOL2, 1)
 	field(LNK1, "$(IN_ACTION=$(P)CS:$(MODE):DUMMYACT:IN) PP")
 	field(LNK2, "$(OUT_ACTION=$(P)CS:$(MODE):DUMMYACT:OUT) PP")


### PR DESCRIPTION
Write 0 on in-range to allow use of same PV for both in and out of range (writes 1 on out of range).

See ISISComputingGroup/IBEX#5786
